### PR TITLE
Update .gitmodules: github -> github.com

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "SwiftGodot"]
 	path = SwiftGodot
-	url = git@github:migueldeicaza/SwiftGodot.git
+	url = git@github.com:migueldeicaza/SwiftGodot.git


### PR DESCRIPTION
When I tried `git submodule update` I got an error. Changing `github` to `github.com` in the url resolved the issue for me.