### PR TITLE
Move IAP signals to listenForTransactions for accurate event handling

### DIFF
--- a/Sources/InAppPurchase/InAppPurchase.swift
+++ b/Sources/InAppPurchase/InAppPurchase.swift
@@ -301,10 +301,8 @@ class InAppPurchase: RefCounted {
 
 			if transaction.revocationDate == nil {
 				self.purchasedProducts.insert(transaction.productID)
-				emit(signal: InAppPurchase.productPurchased, transaction.productID)
 			} else {
 				self.purchasedProducts.remove(transaction.productID)
-				emit(signal: InAppPurchase.productRevoked, transaction.productID)
 			}
 		}
 	}
@@ -323,6 +321,11 @@ class InAppPurchase: RefCounted {
 			for await result: VerificationResult<Transaction> in Transaction.updates {
 				do {
 					let transaction: Transaction = try self.checkVerified(result)
+					if transaction.revocationDate == nil {
+						self.emit(signal: InAppPurchase.productPurchased, transaction.productID)
+					} else {
+						self.emit(signal: InAppPurchase.productRevoked, transaction.productID)
+					}
 
 					await self.updateProductStatus()
 					await transaction.finish()


### PR DESCRIPTION
## Introduction

In the current in-app purchase system, signals play a crucial role in granting or revoking in-game items or currency. If these signals are emitted multiple times, items may be granted repeatedly, or if consumable item purchases are not detected, items may not be granted at all. Based on my understanding of signal usage, I believe the current API implementation is not appropriate.

## Current Issues

The current in-app purchase system has the following issues:

1. **Unable to detect consumable items**: `Transaction.currentEntitlements` [does not include consumable items](https://developer.apple.com/forums/thread/723025), making it impossible to detect these purchases.

2. **Duplicate signals for non-consumable items**: `updateProductStatus()` checks `Transaction.currentEntitlements` and emits signals for already processed non-consumable items multiple times throughout the app's lifecycle - not just at startup, but potentially whenever the app returns from background, when new purchases occur, or when the method is explicitly called.

## StoreKit 2 API Characteristics

StoreKit 2 provides two main APIs:

1. `Transaction.currentEntitlements`
   - Provides information on all permanent products the user has access to
   - Includes: non-consumable items, subscriptions (does not include consumable items)
   - Characteristic: can be called multiple times throughout the app's lifecycle, returning all valid entitlements each time

2. `Transaction.updates`
   - Provides real-time transaction change events
   - Includes: all types of transactions (consumable, non-consumable, subscriptions)
   - Characteristic: emits events only once per transaction change

## Signal Use Case and API Mismatch

Based on my understanding of signal usage (for granting/revoking items):

1. `Transaction.currentEntitlements` is not suitable for signal emission:
   - Returns all valid entitlements whenever called, potentially causing duplicate signals
   - Can be triggered multiple times throughout the app's lifecycle
   - Does not include consumable items, making some purchases undetectable
   - Results in duplicate item grants or missing grants

2. `Transaction.updates` is more suitable for signal emission:
   - Emits events only once per transaction change
   - Can detect all types of transactions
   - Provides a continuous stream of transaction updates throughout the app's lifecycle
   - Enables accurate item granting/revoking based on real-time events

## Solution

Change the API usage to match the signal use case:

1. `Transaction.currentEntitlements` (in `updateProductStatus()`)
   - Remove signal emission code
   - Only perform internal state updates

2. `Transaction.updates` (in `listenForTransactions()`)
   - Emit signals for all transaction types
   - Emit signals only once per transaction change, ensuring accurate item granting/revoking

## Expected Benefits

1. **Accurate item granting/revoking**:
   - Consumable items: Grant items exactly once per purchase
   - Non-consumable items: Process accurately without duplicate grants
   - Subscription cancellations: Revoke items exactly once

2. **API usage matching signal use case**:
   - Transaction event-based signal emission
   - Accurate processing without duplicates or omissions

## Implementation Method

By modifying the code to match the signal use case, we can implement a reliable in-app purchase processing system that grants or revokes items exactly once per transaction change, regardless of how many times the app is launched or brought to the foreground.

## Testing Method

To test in-app purchases that occur outside the app, you can use the following method:

1. Go to Settings on your iOS device
2. Navigate to Developer
3. Select Sandbox Apple Account
4. Tap on Transaction Testing